### PR TITLE
no more docker arm builds for the time beeing (only amd64)

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -79,7 +79,7 @@ jobs:
           file: install/docker/Dockerfile
           context: install/docker
 #          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          platforms: linux/amd64,linux/arm/v7
+          platforms: linux/amd64
           push: true
           tags: |
             weigelt38/airsonic-advanced-legacy:latest


### PR DESCRIPTION
no more arm docker builds (only amd 64) for the time being